### PR TITLE
修复已知关于 CDN 源的问题

### DIFF
--- a/src/components/ImageModal.vue
+++ b/src/components/ImageModal.vue
@@ -204,7 +204,7 @@ const Upload = async (type) => {
               upload_list.value[i].status = 'success'
               e.url = image.url
               e.download_url = image.download_url
-              e.cdn_url = `https://cdn.jsdelivr.net/gh/${github_config.owner}/${github_config.repoPath}@master/${folder.value}/${filename}`
+              e.cdn_url = `https://git.pink/${github_config.owner}/${github_config.repoPath}/blob/main/${folder.value}/${filename}?raw=true`
               e.git_url = image.git_url
               e.sha = image.sha
               e.upload_type = type

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -50,7 +50,7 @@ const GetImages = (folderPath) => {
       emit('SetLoading', false)
       res.data.forEach((e) => {
         if (e.download_url) {
-          e.cdn_url = `https://cdn.jsdelivr.net/gh/${github_config.owner}/${github_config.repoPath}@master/${folderPath}/${e.name}`
+          e.cdn_url = `https://git.pink/${github_config.owner}/${github_config.repoPath}/blob/main/${folderPath}/${e.name}?raw=true`
         }
       })
 


### PR DESCRIPTION
更换 CDN 源为自建 GitHub 镜像。
镜像基于 Cloudflare Workers 搭建，流量是 Pro 版本的，比较客观，望采纳。